### PR TITLE
Loop OSI trace playback

### DIFF
--- a/src/glwidget.cpp
+++ b/src/glwidget.cpp
@@ -78,8 +78,8 @@ void GLWidget::initializeGL()
 {
     if (!initializeOpenGLFunctions())
     {
-        qDebug() << "failed to initialize OpenGL functions";
-        return;
+        qDebug() << "failed to initialize OpenGL functions! Please make sure that OpenGL 4.3 is available on your system!";
+        exit(1);
     }
     // Disabling the depth test.
     // We are simulating a plain 2D world, thus all elements have the same y value.


### PR DESCRIPTION
* Adjusted the osi-visualizer to loop OSI trace playbacks after reaching
  the trace file's end.

- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.